### PR TITLE
Proper CMake tree 

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -32,7 +32,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Test
-      working-directory: ${{github.workspace}}/build
+      working-directory: ${{github.workspace}}/build/test
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,58 +7,11 @@ add_library(cmatrix STATIC src/sparse.c
         src/dense.c
         include/sparse.h
         include/dense.h
-        test/dense_mread/test_mread.c
 )
 target_include_directories(cmatrix PUBLIC include)
 
-# Enable testing
-enable_testing()
+add_subdirectory(test)
 
-# Test executable for mread
-add_executable(test_sparse_mread test/sparse_mread/test_mread.c)
-target_link_libraries(test_sparse_mread PRIVATE cmatrix)
-target_include_directories(test_sparse_mread PRIVATE include)
 
-configure_file(
-        ${CMAKE_SOURCE_DIR}/test/sparse_mread/mread_input_0.txt
-        ${CMAKE_BINARY_DIR}/sparse_mread_input_0.txt
-        COPYONLY
-)
 
-configure_file(
-        ${CMAKE_SOURCE_DIR}/test/sparse_mread/mread_input_1.txt
-        ${CMAKE_BINARY_DIR}/sparse_mread_input_1.txt
-        COPYONLY
-)
 
-configure_file(
-        ${CMAKE_SOURCE_DIR}/test/sparse_mread/mread_input_2.txt
-        ${CMAKE_BINARY_DIR}/sparse_mread_input_2.txt
-        COPYONLY
-)
-
-add_test(NAME test_sparse_mread COMMAND test_sparse_mread)
-
-add_executable(test_dense_mread test/dense_mread/test_mread.c)
-target_link_libraries(test_dense_mread PRIVATE cmatrix)
-target_include_directories(test_dense_mread PRIVATE include)
-
-configure_file(
-        ${CMAKE_SOURCE_DIR}/test/dense_mread/mread_input_0.txt;
-        ${CMAKE_BINARY_DIR}/dense_mread_input_0.txt
-        COPYONLY
-)
-
-configure_file(
-        ${CMAKE_SOURCE_DIR}/test/dense_mread/mread_input_1.txt;
-        ${CMAKE_BINARY_DIR}/dense_mread_input_1.txt
-        COPYONLY
-)
-
-configure_file(
-        ${CMAKE_SOURCE_DIR}/test/dense_mread/mread_input_2.txt;
-        ${CMAKE_BINARY_DIR}/dense_mread_input_2.txt
-        COPYONLY
-)
-
-add_test(NAME test_dense_mread COMMAND test_dense_mread)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+enable_testing()
+
+add_subdirectory(dense_mread)
+
+add_subdirectory(sparse_mread)

--- a/test/dense_mread/CMakeLists.txt
+++ b/test/dense_mread/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Test executable for mread
+add_executable(test_dense_mread test_mread.c)
+target_link_libraries(test_dense_mread PRIVATE cmatrix)
+target_include_directories(test_dense_mread PRIVATE include)
+
+configure_file(
+        mread_input_0.txt
+        dense_mread_input_0.txt
+        COPYONLY
+)
+
+configure_file(
+        mread_input_1.txt
+        dense_mread_input_1.txt
+        COPYONLY
+)
+
+configure_file(
+        mread_input_2.txt
+        dense_mread_input_2.txt
+        COPYONLY
+)
+
+add_test(NAME test_dense_mread COMMAND test_dense_mread)

--- a/test/dense_mread/CMakeLists.txt
+++ b/test/dense_mread/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Test executable for mread
 add_executable(test_dense_mread test_mread.c)
 target_link_libraries(test_dense_mread PRIVATE cmatrix)
-target_include_directories(test_dense_mread PRIVATE include)
+target_include_directories(test_dense_mread PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 configure_file(
         mread_input_0.txt

--- a/test/sparse_mread/CMakeLists.txt
+++ b/test/sparse_mread/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Test executable for mread
+add_executable(test_sparse_mread test_mread.c)
+target_link_libraries(test_sparse_mread PRIVATE cmatrix)
+target_include_directories(test_sparse_mread PRIVATE include)
+
+configure_file(
+        mread_input_0.txt
+        sparse_mread_input_0.txt
+        COPYONLY
+)
+
+configure_file(
+        mread_input_1.txt
+        sparse_mread_input_1.txt
+        COPYONLY
+)
+
+configure_file(
+        mread_input_2.txt
+        sparse_mread_input_2.txt
+        COPYONLY
+)
+
+add_test(NAME test_sparse_mread COMMAND test_sparse_mread)

--- a/test/sparse_mread/CMakeLists.txt
+++ b/test/sparse_mread/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Test executable for mread
 add_executable(test_sparse_mread test_mread.c)
 target_link_libraries(test_sparse_mread PRIVATE cmatrix)
-target_include_directories(test_sparse_mread PRIVATE include)
+target_include_directories(test_sparse_mread PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 configure_file(
         mread_input_0.txt


### PR DESCRIPTION
This pull request refactors the CMake build and test configuration to improve modularity and maintainability. The main change is moving test setup logic for `dense_mread` and `sparse_mread` into their own subdirectories, simplifying the root `CMakeLists.txt` and making test management more organized. Additionally, the GitHub Actions workflow is updated to run tests from the correct directory.

**CMake configuration refactoring:**

* Moved test configuration for `dense_mread` and `sparse_mread` out of the root `CMakeLists.txt` and into separate `CMakeLists.txt` files within their respective subdirectories, cleaning up the main build file and improving modularity. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL10-L64) [[2]](diffhunk://#diff-daf311a39be9cd69d3b94c37d83f8f66ac8ecf625527cbc78e2e0cd44b3ad4bfR1-R24) [[3]](diffhunk://#diff-f4da2b2256121999896c7969646c8fae8568324a2121d6814131c36a6cd0585dR1-R24) [[4]](diffhunk://#diff-33394812ba204689144fd2f80832db83853ba1cb32403edb4e15fe4893e675fdR1-R5)
* Added a new `test/CMakeLists.txt` to enable testing and include the `dense_mread` and `sparse_mread` subdirectories, centralizing test setup.

**CI workflow update:**

* Changed the working directory for the test step in `.github/workflows/cmake-single-platform.yml` to `build/test`, ensuring tests are executed from the correct location after the new test structure.